### PR TITLE
Bug: Similar Dev Tool messaging conflict & QL Operations with empty operation names

### DIFF
--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -11,6 +11,8 @@ export type EventLogStore = {
     queriesStore: Object;
   };
   cache?: Object;
+  queries?: Object;
+  mutations?: Object;
 };
 
 export class EventLogContainer {

--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import {EventBase, MutationStoreValue} from './lib/apollo11types';
-import eventLogIsDifferent from './lib/objectDifference';
+import eventLogIsDifferent, {validateOperationName} from './lib/objectDifference';
 import EventLogDataObject from './lib/eventLogData';
 import EventNode from './lib/eventLogNode';
 
@@ -54,6 +54,7 @@ export class EventLogContainer {
     eventLog: EventLogStore,
     setEvents?: React.Dispatch<React.SetStateAction<{}>>,
   ) {
+    console.log('Query Log :: ', eventLog);
     const {
       queryManager: {mutationStore, queriesStore},
       eventId,
@@ -61,15 +62,18 @@ export class EventLogContainer {
     } = eventLog;
     let evtNum = 0;
     // perform queriesStore Check
+    console.log('Query Manager - Mutation :: ', mutationStore);
+    console.log('Query Manager - QueryStore :: ', queriesStore);
     Object.keys(queriesStore).forEach(storeKey => {
-      // console.log('Query Snapshot :: ', queriesStore[storeKey]);
+      console.log('Query Snapshot :: ', queriesStore[storeKey]);
+      console.log(validateOperationName(queriesStore[storeKey].document.definitions, 'Query'))
       const proposedQry: EventNode = new EventNode({
         event: {
           ...queriesStore[storeKey],
           request: {
             operation: {
               operationName:
-                queriesStore[storeKey].document.definitions[0].name.value,
+                validateOperationName(queriesStore[storeKey].document.definitions, 'Query'),
               query: queriesStore[storeKey].document.loc.source.body,
             },
           },
@@ -111,7 +115,7 @@ export class EventLogContainer {
           request: {
             operation: {
               operationName:
-                mutationStore[storeKey].mutation.definitions[0].name.value,
+                validateOperationName(mutationStore[storeKey].mutation.definitions, 'Mutation'),
               query: mutationStore[storeKey].mutation.loc.source.body,
             },
           },

--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -54,22 +54,20 @@ export class EventLogContainer {
     eventLog: EventLogStore,
     setEvents?: React.Dispatch<React.SetStateAction<{}>>,
   ) {
-    console.log('Query Log :: ', eventLog);
+    // console.log('Query Log :: ', eventLog);
     const {
       queryManager: {mutationStore, queriesStore},
       eventId,
       cache,
+      queries, mutations
     } = eventLog;
     let evtNum = 0;
     // perform queriesStore Check
-    console.log('Query Manager - Mutation :: ', mutationStore);
-    console.log('Query Manager - QueryStore :: ', queriesStore);
     Object.keys(queriesStore).forEach(storeKey => {
-      console.log('Query Snapshot :: ', queriesStore[storeKey]);
-      console.log(validateOperationName(queriesStore[storeKey].document.definitions, 'Query'))
       const proposedQry: EventNode = new EventNode({
         event: {
           ...queriesStore[storeKey],
+          'variables': queriesStore[storeKey].variables ? queriesStore[storeKey].variables : queries && queries.hasOwnProperty(storeKey) && queries[storeKey].variables ? queries[storeKey].variables : {},
           request: {
             operation: {
               operationName:
@@ -97,7 +95,7 @@ export class EventLogContainer {
             },
             {
               document: queriesStore[storeKey].document,
-              variables: queriesStore[storeKey].variables,
+              variables: queriesStore[storeKey].variables ? queriesStore[storeKey].variables : queries && queries.hasOwnProperty(storeKey) && queries[storeKey].variables ? queries[storeKey].variables : {},
               // diff: null, //queriesStore[storeKey].diff,
             },
           )
@@ -112,6 +110,9 @@ export class EventLogContainer {
       const proposedMutate: EventNode = new EventNode({
         event: {
           ...mutationStore[storeKey],
+          'variables': mutationStore[storeKey].variables ? mutationStore[storeKey].variables : mutations && mutations.hasOwnProperty(storeKey) && mutations[storeKey].variables ? mutations[storeKey].variables : {},
+          'loading': mutationStore[storeKey].loading ? mutationStore[storeKey].loading : mutations && mutations.hasOwnProperty(storeKey) && mutations[storeKey].loading ? mutations[storeKey].loading : {},
+          'error': mutationStore[storeKey].variables ? mutationStore[storeKey].error : mutations && mutations.hasOwnProperty(storeKey) && mutations[storeKey].error ? mutations[storeKey].error : {},
           request: {
             operation: {
               operationName:
@@ -144,9 +145,9 @@ export class EventLogContainer {
             },
             {
               mutation: mutationStore[storeKey].mutation,
-              variables: mutationStore[storeKey].variables,
-              loading: mutationStore[storeKey].loading,
-              error: mutationStore[storeKey].error,
+              variables: mutationStore[storeKey].variables ? mutationStore[storeKey].variables : mutations && mutations.hasOwnProperty(storeKey) && mutations[storeKey].variables ? mutations[storeKey].variables : {},
+              loading: mutationStore[storeKey].loading ? mutationStore[storeKey].loading : mutations && mutations.hasOwnProperty(storeKey) && mutations[storeKey].loading ? mutations[storeKey].loading : {},
+              error: mutationStore[storeKey].error ? mutationStore[storeKey].error : mutations && mutations.hasOwnProperty(storeKey) && mutations[storeKey].error ? mutations[storeKey].error : {},
               // diff: null, //mutationStore[storeKey].diff,
             },
           )

--- a/src/app/utils/managedlog/lib/objectDifference.ts
+++ b/src/app/utils/managedlog/lib/objectDifference.ts
@@ -1,4 +1,5 @@
 // import {equal} from '@wry/equality';
+import {DocumentNode, DefinitionNode} from 'graphql';
 
 const isLogValuePrimitive = (val: any): boolean => {
   return val == null || /^[sbn]/.test(typeof val);
@@ -21,5 +22,43 @@ const eventLogIsDifferent = (a: any, b: any): boolean => {
     })
   );
 };
+
+/**
+ * 
+ * @param objStore : ReadonlyArray<Record<string, any>>
+ * @param objType : string
+ * 
+ * Desc:: processes the document.definitions or mutation.definitions of the query/mutation operation
+ *        this was necessary as some clients do not have a name.value on the document/mutation object
+ *        especially then having to get the operations names form the list of sections that make up the operation
+ * Returns the operation name of the query or mutation
+ */
+export const validateOperationName = (objStore: ReadonlyArray<Record<string, any>>, objType: string): string => {
+  if (objStore.length) {
+    if (objStore[0].name) {
+      return objStore[0].name.value;
+    } else {
+      if (objStore[0].selectionSet && objStore[0].selectionSet.selections) {
+        if (objStore[0].selectionSet.selections.length) {
+          return objStore[0].selectionSet.selections.reduce((operationName, selection) => {
+              // reduce selectionSet.selections Array's name.value to an array of name values
+              return selection && selection.name && selection.name.value ? [...operationName, selection.name.value.toLowerCase()] : operationName;
+            }, []).reduce((opera, curr) => {
+              // reduce array of names values to a string padding front and back with ( & ) respectively
+              if (curr.toLowerCase().trim().length > 0) {
+                if (opera === objType.toLowerCase()) {
+                  opera = `${opera} (${curr.toLowerCase().trim()})`
+                } else {
+                  opera = `${opera.substr(0, opera.length - 1)}, ${curr.toLowerCase().trim()})`
+                }
+              }
+              return opera;
+            }, `${objType.toLowerCase()}`);
+        }
+      }
+    }
+  }
+  return objType.toLowerCase();
+}
 
 export default eventLogIsDifferent;

--- a/src/app/utils/managedlog/lib/objectDifference.ts
+++ b/src/app/utils/managedlog/lib/objectDifference.ts
@@ -1,5 +1,4 @@
 // import {equal} from '@wry/equality';
-import {DocumentNode, DefinitionNode} from 'graphql';
 
 const isLogValuePrimitive = (val: any): boolean => {
   return val == null || /^[sbn]/.test(typeof val);
@@ -24,16 +23,14 @@ const eventLogIsDifferent = (a: any, b: any): boolean => {
 };
 
 /**
- * 
  * @param objStore : ReadonlyArray<Record<string, any>>
- * @param objType : string
- * 
+ * @param objType : string 
  * Desc:: processes the document.definitions or mutation.definitions of the query/mutation operation
  *        this was necessary as some clients do not have a name.value on the document/mutation object
  *        especially then having to get the operations names form the list of sections that make up the operation
  * Returns the operation name of the query or mutation
  */
-export const validateOperationName = (objStore: ReadonlyArray<Record<string, any>>, objType: string): string => {
+export const validateOperationName = (objStore: ReadonlyArray<Record<string, any>>, objType: string,): string => {
   if (objStore.length) {
     if (objStore[0].name) {
       return objStore[0].name.value;
@@ -43,13 +40,13 @@ export const validateOperationName = (objStore: ReadonlyArray<Record<string, any
           return objStore[0].selectionSet.selections.reduce((operationName, selection) => {
               // reduce selectionSet.selections Array's name.value to an array of name values
               return selection && selection.name && selection.name.value ? [...operationName, selection.name.value.toLowerCase()] : operationName;
-            }, []).reduce((opera, curr) => {
+            }, []).reduce((opera: string, curr: string): string => {
               // reduce array of names values to a string padding front and back with ( & ) respectively
               if (curr.toLowerCase().trim().length > 0) {
                 if (opera === objType.toLowerCase()) {
-                  opera = `${opera} (${curr.toLowerCase().trim()})`
+                  return `${opera} (${curr.toLowerCase().trim()})`;
                 } else {
-                  opera = `${opera.substr(0, opera.length - 1)}, ${curr.toLowerCase().trim()})`
+                  return `${opera.substr(0, opera.length - 1)}, ${curr.toLowerCase().trim()})`;
                 }
               }
               return opera;

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -34,7 +34,6 @@ export default function createApolloClientListener(
     if (eventId === 'null') {
       eventId = '0';
     }
-
     const {cache, queryManager, queries, mutations} = request;
     eventList.sequenceApolloLog({queryManager, eventId, cache, queries, mutations}, setEvents);
   });

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -35,8 +35,8 @@ export default function createApolloClientListener(
       eventId = '0';
     }
 
-    const {cache, queryManager} = request;
-    eventList.sequenceApolloLog({queryManager, eventId, cache}, setEvents);
+    const {cache, queryManager, queries, mutations} = request;
+    eventList.sequenceApolloLog({queryManager, eventId, cache, queries, mutations}, setEvents);
   });
 }
 

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -32,6 +32,10 @@ window.addEventListener(
       return;
     }
 
+    if (!event.data.type || !event.data.eventId) {
+      return;
+    }
+
     const apolloClient = {
       type: event.data.type,
       eventId: event.data.eventId,


### PR DESCRIPTION
**Feature**:
Fixed Bug associated with presence of Apollo Client Dev Tool causing conflicts in message plumbing bwt ApolloDevQL's hook and dev panel. 
Fixed Bug associated with Empty Operation names (hoping to avoid naming events as Mutation or Query)

**Description**
1.  Added queries & mutations key to EventLogStore type.
2. Added a helper method to validate operation.name.value and return a valid operationName as against undefined when apollo client QLs have no operation name in the root document/mutation object
3. Now included root queries & mutations from the hook callback as an alternate source of truth to EventObject.sequenceApolloLog to help fetch keys that are not in the constructed QueryManager.


**How to Test**
     1. npm run build
     2. open this website https://shopping.qantas.com/apple, perform site operations
     3. Observe the ApolloDevQL panel.