### PR TITLE
Update manifest from all_urls to http://* https://*

### DIFF
--- a/src/extension/build/manifest.json
+++ b/src/extension/build/manifest.json
@@ -13,7 +13,7 @@
   "web_accessible_resources": ["bundles/apollo.bundle.js"],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["http://*/*", "https://*/*"],
       "js": ["bundles/content.bundle.js"]
     }
   ]


### PR DESCRIPTION
**Feature**
Chrome extension manifest

**Description**
This PR changes the `[matches]` array based on feedback from the Chrome team.  It no longer tries to match against `all_urls` but instead restricts to any `http` or `https` site.
